### PR TITLE
Multilingual templates using ModelTranslation

### DIFF
--- a/post_office/admin.py
+++ b/post_office/admin.py
@@ -5,6 +5,11 @@ from django.utils.text import Truncator
 from .fields import CommaSeparatedEmailField
 from .models import Email, Log, EmailTemplate, STATUS
 
+try:
+    from modeltranslation.admin import TranslationAdmin
+except ImportError:
+    from django.contrib.admin import ModelAdmin as TranslationAdmin
+
 
 def get_message_preview(instance):
     return (u'{0}...'.format(instance.message[:25]) if len(instance.message) > 25
@@ -60,7 +65,7 @@ class LogAdmin(admin.ModelAdmin):
     list_display = ('date', 'email', 'status', get_message_preview)
 
 
-class EmailTemplateAdmin(admin.ModelAdmin):
+class EmailTemplateAdmin(TranslationAdmin):
     list_display = ('name', 'description_shortened', 'subject', 'created')
     search_fields = ('name', 'description', 'subject')
     fieldsets = [
@@ -76,7 +81,6 @@ class EmailTemplateAdmin(admin.ModelAdmin):
         return Truncator(instance.description.split('\n')[0]).chars(200)
     description_shortened.short_description = 'description'
     description_shortened.admin_order_field = 'description'
-
 
 admin.site.register(Email, EmailAdmin)
 admin.site.register(Log, LogAdmin)

--- a/post_office/translation.py
+++ b/post_office/translation.py
@@ -1,0 +1,9 @@
+from modeltranslation.translator import translator, TranslationOptions
+
+from .models import EmailTemplate
+
+
+class EmailTemplateTranslationOptions(TranslationOptions):
+    fields = ('subject', 'content', 'html_content', )
+
+translator.register(EmailTemplate, EmailTemplateTranslationOptions)


### PR DESCRIPTION
Added a optional dependency for [ModelTranslation](https://github.com/deschler/django-modeltranslation) this will allow users a easy way to support mail template translations.
This is related to ui/django-post_office#32
